### PR TITLE
increase timeout to 10 hours

### DIFF
--- a/service-scripts/App-SequenceSubmission.pl
+++ b/service-scripts/App-SequenceSubmission.pl
@@ -31,7 +31,7 @@ sub preflight
     return {
 	cpu => 2,
 	memory => "16G",
-	runtime => 18000,
+	runtime => 36000,
 	storage => 0,
     };
 }


### PR DESCRIPTION
We receive large number of sequences every once in a while and current 5 hour limitation is not enough 